### PR TITLE
Add COC page to redirect users to the Code of Conduct

### DIFF
--- a/app/coc/page.jsx
+++ b/app/coc/page.jsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function COC() {
+  redirect('/code-of-conduct');
+}


### PR DESCRIPTION
- Introduced a new COC component in page.jsx that redirects users to the '/code-of-conduct' route.
- This addition simplifies navigation to the Code of Conduct, ensuring users can easily access important guidelines.

The change aims to enhance user experience by providing a clear path to the Code of Conduct while adhering to clean coding principles.